### PR TITLE
Use 20 items for rss by default

### DIFF
--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -13,7 +13,7 @@
     {{ with .OutputFormats.Get "RSS" }}
         {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
     {{ end }}
-    {{ range .Site.RegularPages }}
+    {{ range (.Paginate .Site.RegularPages 20).Pages }}
     <item>
       <title>{{ .Title }}</title>
       <link>{{ .Permalink }}</link>


### PR DESCRIPTION
Motivation: limit number of items in RSS feed