### PR TITLE
Fixes missing slash on index pages

### DIFF
--- a/exampleSite/config.yml
+++ b/exampleSite/config.yml
@@ -20,7 +20,7 @@ outputFormats:          # use for search. recommend not to modify
     baseName: "searchindex"
     isPlainText: true
     notAlternative: true
-    
+
 outputs:
     home: ["HTML","RSS","SearchIndex"]  # recommend not to modify
 # sitemap
@@ -33,32 +33,32 @@ menu:
   main:
     - identifier: home
       name: Home
-      title: Home 
+      title: Home
       url: /
       weight: 1
 
     - identifier: archives
       name: Archives
       title: Archives
-      url: /posts
+      url: /posts/
       weight: 2
 
     - identifier: categories
       name: Categories
       title: Categories
-      url: /categories
+      url: /categories/
       weight: 3
 
     - identifier: tags
       name: Tags
       title: Tags
-      url: /tags
+      url: /tags/
       weight: 4
 
     - identifier: about
       name: About
       title: About
-      url: /about
+      url: /about/
       weight: 5
 
 

--- a/layouts/_default/category.html
+++ b/layouts/_default/category.html
@@ -7,7 +7,7 @@
             <p class="text-muted hidden-xs">{{- T "total_category" (len $categories) }}</p>
             <nav role="navigation" id="nav-main" class="okayNav">
                 <ul>
-                    <li><a href="{{- "categories" | relURL }}">{{- T "nav_all" }}</a></li>
+                    <li><a href="{{- "categories/" | relURL }}">{{- T "nav_all" }}</a></li>
                     {{- range $categories }}
                     <li><a href="{{ .Page.Permalink }}">{{ .Page.Title }}</a></li>
                     {{- end }}


### PR DESCRIPTION
Avoids "target is a directory, href lacks trailing slash" error when
linting with htlmtest.

Fixes: #60