### PR TITLE
Allow full text customization for counters

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -84,9 +84,9 @@ unit_time:
   other: minutes
 
 article_wordcount:
-  other: Word Count
+  other: "Word Count: "
 article_readcount:
-  other: Read Count
+  other: "Read Count: "
 article_more:
   other: Read More
 article_comments:

--- a/i18n/zh.yaml
+++ b/i18n/zh.yaml
@@ -88,9 +88,9 @@ unit_time:
   other: 分
 
 article_wordcount:
-  other: 字数统计
+  other: "字数统计: "
 article_readcount:
-  other: 阅读时长
+  other: "阅读时长: "
 article_more:
   other: 查看更多
 article_comments:

--- a/layouts/partials/post/wc.html
+++ b/layouts/partials/post/wc.html
@@ -2,9 +2,9 @@
 {{- $page := .Page}}
 {{- with $postCount.enable }}
 	{{- with $postCount.wordcount }}
-		<span class="post-wordcount hidden-xs" itemprop="wordCount">{{ T "article_wordcount" -}}: {{- $page.WordCount }}{{ T "unit_word" }}</span>
+		<span class="post-wordcount hidden-xs" itemprop="wordCount">{{ T "article_wordcount" -}}{{- $page.WordCount }}{{ T "unit_word" }}</span>
 	{{- end }}
 	{{- with $postCount.min2read }}
-		<span class="post-readcount hidden-xs" itemprop="timeRequired">{{ T "article_readcount" }}: {{- $page.ReadingTime }}{{ T "unit_time" }} </span>
+		<span class="post-readcount hidden-xs" itemprop="timeRequired">{{ T "article_readcount" }}{{- $page.ReadingTime }}{{ T "unit_time" }} </span>
 	{{- end }}
 {{- end }}


### PR DESCRIPTION
Includes the suffix ": " in the language string in order to allow us to
customize it.

This also enables us to define an override as an empty string.

That change should not affect users that did not customize that strings.