### PR TITLE
fix asciidoc post render issue.

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -6024,11 +6024,11 @@ body.no-sidebar .sidebar {
   margin-left: 10px;
 }
 
-.main .content {
+.main {
   min-height: 85vh;
 }
 
-.main.has-sticky .content {
+.main.has-sticky {
   margin-bottom: 70px;
 }
 


### PR DESCRIPTION
There is a big blank area after image and code block in asciidoc post.
e.g.
![image](https://user-images.githubusercontent.com/9191275/104822930-29307880-5881-11eb-9ffd-77f2eb2cf61a.png)
![image](https://user-images.githubusercontent.com/9191275/104822941-46654700-5881-11eb-8bbe-be154cd54aa5.png)

This issue happens when render image and code block in asciidoc post. The two HTML items are wrapped in `div` with class 'content', which has two style `min-height: 85vh` and `margin-bottom: 70px`.

This PR is removing the two style to fix this issue.